### PR TITLE
Fix for DogNZB CSS Issues

### DIFF
--- a/sites/dognzb.js
+++ b/sites/dognzb.js
@@ -4,6 +4,11 @@
 (function() {
     'use strict';
     function injectBrowsingMode() {
+        let parentNode = document.querySelector('tbody tr td[width="18"]').parentNode;
+        let childNode = document.querySelector('tbody tr td[width="18"]');
+        let newNode = document.createElement('td');
+        newNode.setAttribute('width', 18);
+        parentNode.insertBefore(newNode, childNode);
         var dllinks = document.querySelectorAll('div.dog-icon-download');
         for(var i = 0; i < dllinks.length; i++) {
             var dlitem = dllinks.item(i);


### PR DESCRIPTION
An error with the table header in DogNZB was causing titles to be cut off. This update adds a necessary column to the first table row so all the column widths will be correct.